### PR TITLE
feat: add result collection debug logging

### DIFF
--- a/bin/goatsearch.py
+++ b/bin/goatsearch.py
@@ -354,6 +354,15 @@ class goatsearch(GeneratingCommand):
 
                     # TODO: We have to account for the fact these results may be out of time-order.
 
+                    if self.debug:
+                        yield {
+                            "_raw": json.dumps({"url": results_uri}),
+                            "_time": time.time(),
+                            "source": "goatsearch",
+                            "sourcetype": "goatsearch:debug",
+                            "host": "localhost"
+                        }
+
                     self.headers['Accept'] = 'application/x-nd-json'
 
                     results_chunk = requests.get(


### PR DESCRIPTION
## Summary

Adds a single debug output point in the result collection loop to aid troubleshooting.

When `debug=True`, emits a debug event before each result fetch showing `results_uri` which contains:
- `uri`: Cribl URL
- `job_id`: search job id
- `api_limit`: Configured API page size limit
- `offset`: Current position in result set

## Motivation

When investigating search behavior or performance, having visibility into the result collection loop iterations is valuable. This makes it easier to:
- Verify pagination is working as expected
- Correlate API calls with result counts
- Identify any unexpected collection patterns

## Implementation

- Single debug statement before the `requests.get()` call
- Uses distinct sourcetype `goatsearch:debug` for easy filtering
- Zero overhead when `debug=False` (conditional branch not taken)
- Follows existing debug output patterns

## Testing

Manual testing with `debug=True` confirms the debug events are emitted correctly and provide the expected visibility into collection behavior.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)